### PR TITLE
Dockerfile for auto builds; added Numpy dependency to README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM phusion/baseimage:latest
+MAINTAINER Justin Payne, justin.payne@fda.hhs.gov
+
+WORKDIR /tmp/
+RUN apt-get update && apt-get install -y \
+	git \
+	seq-gen \
+	python \
+	python-dev \
+	python-pip 
+RUN curl -O http://www.niehs.nih.gov/research/resources/assets/docs/artbinvanillaicecream031114linux64tgz.tgz
+RUN tar -xzvf ./artbinvanillaicecream031114linux64tgz.tgz
+RUN export PATH="$PATH:$PWD/artbinvanillaicecream031114linux64"
+
+RUN pip install dendropy numpy
+RUN git clone https://github.com/snacktavish/TreeToReads.git
+
+WORKDIR /tmp/TreeToReads/
+
+ENTRYPOINT python /tmp/TreeToReads/treetoreads.py

--- a/README
+++ b/README
@@ -6,6 +6,7 @@ Installed globally
 
 python packages
    Dendropy
+   Numpy
 
 
 -------------------------
@@ -19,7 +20,7 @@ wget http://www.niehs.nih.gov/research/resources/assets/docs/artbinvanillaicecre
 tar -xzvf artbinvanillaicecream031114linux64tgz.tgz
 ## So, then you need to add artbinvanillaicecream031114linux64tgz to your path. A bit annoying.
 
-easy_install dendropy
+easy_install dendropy numpy
 
 -----------------------------------------------------------
 Running the simulations:


### PR DESCRIPTION
Hi Dr. McTavish, this is Justin Payne (justin.payne@fda.hhs.gov); I work with Dr. Ruth Timme at FDA-CFSAN. I'm creating this pull request with one new item and one change:

* Edited 'README' to note Numpy as a required Python package.

* Added 'Dockerfile' for containerized builds using [Docker.](https://docs.docker.com/)

Additionally, with a Dockerfile in the repo you can set up [automated Docker builds](http://docs.docker.com/docker-hub/builds/) tied to Github commits, which Docker users can use via 

`docker run -v $PWD:/work snacktavish/treetoreads:latest /work/my_config.cnf`

or similar. Anyway I'd considered hosting the Docker container myself, but since it would be tied to my Docker registry account, that felt too much like putting my name on your work. But, I think people would benefit from being able to use treeToReads via its Docker container as an easy alternative to trying to install it.

I'm a huge fan of Docker for bioinformatics tools (but I don't work there or anything) so if I can answer any questions please let me know.

Thanks,
Justin Payne
ORISE Bioinformatics Dev
240-402-5127
FDA-CFSAN-ORS-DM-MMSB

