### PR TITLE
Improve README formating and document '_indel.fasta' files

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,12 +141,12 @@ art_log - log messages from ART software
 ### Docker container
 TreeToReads is also available as a [Docker](https://www.docker.com/) container:
 
-  docker pull snacktavish/treetoreads
-  docker run snacktavish/treetoreads example.config
+    docker pull snacktavish/treetoreads
+    docker run snacktavish/treetoreads example.config
 
 to run the default example, or
 
-  docker run -v /an/example/path:/a/container/path snacktavish/treetoreads /a/container/path/my_treetoreads_config.cfg
+    docker run -v /an/example/path:/a/container/path snacktavish/treetoreads /a/container/path/my_treetoreads_config.cfg
 
 to run on real data, where ```/an/example/path/``` contains the file ```my_treetoreads_config.cfg```.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # TreeToReads
 
-Simulation pipeline to generate next generation sequencing reads from realistic phylogenies.  
-Can be used to test effects of model of evolution, rates of evolution, 
-genomic distribution of mutations, and phylogenetic relatedness of samples and of reference genome 
-on SNP calling and evolutionary inference.  
+Simulation pipeline to generate next generation sequencing reads from realistic phylogenies.
+Can be used to test effects of model of evolution, rates of evolution,
+genomic distribution of mutations, and phylogenetic relatedness of samples and of reference genome
+on SNP calling and evolutionary inference.
 
 TreeToReads (TTR) provides features not available in alternative simulation approaches:
 
@@ -19,12 +19,12 @@ and a set of configuration parameters in a control file
 Optional inputs can include a sequencing error model parameterized from empirical data,
 and a distribution for the distances separating pairs of mutations in the genome.
 
-Outputs are mutated genomes representing all tips in the phylogeny, 
-and simulated whole genome sequencing reads representing those genomes. 
+Outputs are mutated genomes representing all tips in the phylogeny,
+and simulated whole genome sequencing reads representing those genomes.
 These are are useful for testing and comparison of analysis pipelines.
 Mutations are currently only single nucleotide variants - no indels or rearrangements.
 
-The code is still in development - but testing welcome, and will be supported via email ejmctavish, gmail.  
+The code is still in development - but testing welcome, and will be supported via email ejmctavish, gmail.
 
 ## Schematic of TreeToReads procedure
 ![](https://github.com/snacktavish/TreeToReads/blob/master/docs/TTR-figure.png?raw=true)
@@ -52,12 +52,12 @@ python packages
 
     pip install dendropy
 
-##### Install seq-gen, software to simulate mutations (http://tree.bio.ed.ac.uk/software/seqgen/) 
-on ubuntu using apt-get: 
+##### Install seq-gen, software to simulate mutations (http://tree.bio.ed.ac.uk/software/seqgen/)
+on ubuntu using apt-get:
 
     sudo apt-get install seq-gen
 
-on Mac or linux (using homebrew, http://brew.sh/): 
+on Mac or linux (using homebrew, http://brew.sh/):
 
     brew install seq-gen
 
@@ -65,17 +65,17 @@ on Mac or linux (using homebrew, http://brew.sh/):
 ##### Art is optional, but is required to generate reads from simulated genomes
 ##### Install ART, software to generate short reads from simulated genomes (http://www.niehs.nih.gov/research/resources/software/biostatistics/art/)
 
-on ubuntu: 
+on ubuntu:
 
     wget http://www.niehs.nih.gov/research/resources/assets/docs/artbingreatsmokymountains041716linux64tgz.tgz
     tar -xzvf artbingreatsmokymountains041716linux64tgz.tgz
 
 add art_illumina to path (see http://askubuntu.com/questions/60218/how-to-add-a-directory-to-my-path)
 
-on Mac (using homebrew): 
+on Mac (using homebrew):
 
     brew install art
-or 
+or
    wget http://www.niehs.nih.gov/research/resources/assets/docs/artbingreatsmokymountains041716macos64tgz.tgz
    tar -xzvf artbingreatsmokymountains041716macos64tgz.tgz
 
@@ -90,7 +90,7 @@ Note: to compile indelible from source for linux installations currently require
 
     #include <unistd.h>
 
-(I've reported the issue and it shoud be fixed soon)  
+(I've reported the issue and it shoud be fixed soon)
 add indelible to your path
 
 
@@ -101,7 +101,7 @@ add indelible to your path
     git clone https://github.com/snacktavish/TreeToReads.git
     cd TreeToReads
     python treetoreads.py example.config
- 
+
 Edit the configuration file, example.config, to fit your data.
 
 Currently generates paired end illumina data.
@@ -116,37 +116,38 @@ The script print out the parameter values and some other useful info.
 If it runs successfully it will end with
 "TreeToReads completed successfully!"
 
-The output files will be in the the output directory specified in the 
+The output files will be in the the output directory specified in the
 config file, e.g. example_out
 and will consist of:
 
 ## Key files
-fasta_files   - a folder containing the simulated genomes for each tip in the tree  
-fastq - folder containing folders with the names of each tip from the simulation tree, in each of these folders is the gziped simulated fastq.
-sim.vcf - A vcf file for the simulated mutations with respect to the anchor genome. CURRENTLY DUE TO A BUG VCF FILES ARE NOT GENERATED WHEN INDELS ARE SIMULATED. 
-mutsites.txt  - unordered list of the locations of mutations in the genome  
+- **fasta_files**: A folder containing the simulated genomes for each tip in the tree
+  - If INDEL simulation is requested, `*_indel.fasta` files will contain the simulated INDELs, with deletions marked by dash (`-`) characters
+- **fastq**: A folder containing folders with the names of each tip from the simulation tree, in each of these folders is the gziped simulated fastq.
+- **sim.vcf**: A vcf file for the simulated mutations with respect to the anchor genome.
+  CURRENTLY DUE TO A BUG VCF FILES ARE NOT GENERATED WHEN INDELS ARE SIMULATED.
+- **mutsites.txt**: An unordered list of the locations of mutations in the genome
 
-### Other files generated by analysis (mostly useless)  
-analysis_configuration.cfg - a copy of the control file used for the analysis  
-seqgen.out - output messages form the seq-gen software  
-simtree.tre.bu - a backup copy of the tree  
-simtree.tre - the tree used for simulations: reformatted and polytomies randomly resolved with 0 length branches  
-analysis.sh - the bash commands run by the analysis   
-These folders contain the simulated read in fastq format  
-seqs_sim.txt  - an intermediate file used for generating variable sites  
-SNPmatrix - a file in format SEQUENCE, BASE, POSITION describing all variable sites in the genome  
-art_log - log messages from ART software  
+### Other files generated by analysis (mostly useless)
+- *analysis_configuration.cfg*: a copy of the control file used for the analysis
+- *seqgen.out*: output messages form the seq-gen software
+- *simtree.tre.bu*: a backup copy of the tree
+- *simtree.tre*: the tree used for simulations: reformatted and polytomies randomly resolved with 0 length branches
+- *analysis.sh*: the bash commands run by the analysis
+- *seqs_sim.txt*: an intermediate file used for generating variable sites
+- *SNPmatrix*: a file in format SEQUENCE, BASE, POSITION describing all variable sites in the genome
+art_log - log messages from ART software
 
 ### Docker container
 TreeToReads is also available as a [Docker](https://www.docker.com/) container:
 
-	docker pull snacktavish/treetoreads
-	docker run snacktavish/treetoreads example.config
-	
+  docker pull snacktavish/treetoreads
+  docker run snacktavish/treetoreads example.config
+
 to run the default example, or
 
-	docker run -v /an/example/path:/a/container/path snacktavish/treetoreads /a/container/path/my_treetoreads_config.cfg
-	
+  docker run -v /an/example/path:/a/container/path snacktavish/treetoreads /a/container/path/my_treetoreads_config.cfg
+
 to run on real data, where ```/an/example/path/``` contains the file ```my_treetoreads_config.cfg```.
 
 (See the [Docker manual](http://docs.docker.com/engine/reference/run/#volume-shared-filesystems) for more information about mounting host directories in the container.)
@@ -160,9 +161,9 @@ Please cite them (as well as this repo) in any published work using this simulat
 
 McTavish E. J., Timme R, (2015) Tree To Reads. https://github.com/snacktavish/TreeToReads  bioRxiv
 
-Huang W., Li L, Myers J. R., Marth G. T. (2012). ART: a next-generation sequencing read simulator, Bioinformatics 28 (4): 593-594  
+Huang W., Li L, Myers J. R., Marth G. T. (2012). ART: a next-generation sequencing read simulator, Bioinformatics 28 (4): 593-594
 
-Rambaut A. and Grassly N. C. (1997) Seq-Gen: An application for the Monte Carlo simulation of DNA sequence evolution along phylogenetic trees. Comput. Appl. Biosci. 13: 235-238  
+Rambaut A. and Grassly N. C. (1997) Seq-Gen: An application for the Monte Carlo simulation of DNA sequence evolution along phylogenetic trees. Comput. Appl. Biosci. 13: 235-238
 
 Sukumaran, J. and Mark T. Holder. 2010. DendroPy: A Python library for phylogenetic computing. Bioinformatics 26: 1569-1571.
 


### PR DESCRIPTION
First off, great tool!  

I had to dig into the code a little to figure out the difference between the `x.fasta` and `x_indel.fasta` files, and I didn't see them documented anywhere in the README or other docs.  This is a (mostly) cosmetic PR but I did include an additional bullet point explaining what the _indel.fasta files are.  It might be helpful to update the full tutorial describing for INDEL simulations that:

1.  INDELs are simulated, producing the `Tip_indel.fasta` file
2.  The DEL (`-`) sequences are removed to create the `Tip.fasta` file
3.  Then ART simulates the genomes