### PR TITLE
Fix off-by-one error when reporting the number of contigs in the genome.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 sim_*
 *.cfg
 RAxML*
+example_out
+*.egg-info
+build
+dist

--- a/treetoreads.py
+++ b/treetoreads.py
@@ -321,7 +321,7 @@ class TreeToReads(object):
                              of the contig or geonme {}.
                              Exiting\n'''.format(self.nsnp, self.genlen))
             self._exit_handler()
-        sys.stdout.write("genome has {} contigs\n".format(len(self.contig_breaks)))
+        sys.stdout.write("genome has {} contigs\n".format(len(self.contig_names)))
         sys.stdout.write("Genome has {} bases\n".format(self.genlen))
 
     def generate_varsites(self):


### PR DESCRIPTION
Fixes #41 - off-by-one error when reporting the number of contigs in the genome.  

Also updates the .gitignore file.