### PR TITLE
Support for threading and additional read simulation parameters

### DIFF
--- a/example.config
+++ b/example.config
@@ -1,36 +1,16 @@
 #REQUIRED PARAMETERS
-treefile_path =  /storage/CompGenomics/CompGenomics2019/datasets/listeria/outbreak/listeria.nwk
-number_of_variable_sites = 17
-base_genome_name = CGT3538
-base_genome_path =  /storage/CompGenomics/CompGenomics2019/datasets/listeria/outbreak/ref.fa
-output_dir =  /storage/CompGenomics/Compgenomics2020/datasets/listeria/outbreak
-#coverage_low = 23 # Start of random coverage range
-#coverage_high = 87 # End of random coverage range
-#coverage_step = 1 # Step size for binning random coverage
-#read_length = 150,250 # Read length, can be one value or list of comma separated values
-#frag_low = 600 # Start of random frag length range
-#frag_high = 1000 # End of random frag length range
-#frag_step = 7 # Step size for binning frag length
-#stdev_frag_low = 10 # Start of random frag length stdev range
-#stdev_frag_high = 100 # End of random frag length stdev range
-#stdev_frag_step = 3 # Step size for binning frag length stdev
-#qs2_low = -3 # Start of QS2 bias range
-#qs2_high = 0 # End of QS2 bias range
-#qs2_step = 1 # Step size for binning QS2 bias
-readProfile = MSv3 # Read platform
-# Supports the following (between read length)
-# Defaults to MiSeq v3 to allow reads up to 250bp
-# GA1 - GenomeAnalyzer I (1-44bp), GA2 - GenomeAnalyzer II (1-75bp)
-# HS10 - HiSeq 1000 (1-100bp), HS20 - HiSeq 2000 1-100bp), HS25 - HiSeq 2500 (1-150bp)
-# HSXn - HiSeqX PCR free (1-150bp), HSXt - HiSeqX TruSeq (1-150bp),  MinS - MiniSeq TruSeq (1-50bp)
-# MSv1 - MiSeq v1 (1-250bp), MSv3 - MiSeq v3 (1-250bp), NS50 - NextSeq500 v2 (1-75bp)
-#parameters of evolutionary model (comma seperated), in order ac, ag, at, cg, ct, gc (gc = 1)
+treefile_path =  example/example.tre
+number_of_variable_sites = 20
+base_genome_name = gi
+base_genome_path =  example/mini_ref.fasta
+output_dir = example_out
+# parameters of evolutionary model (comma seperated), in order ac, ag, at, cg, ct, gc (gc = 1)
 rate_matrix = 1,1,1,1,1,1
 
 
 
-#OPTIONAL PARAMETERS
-#prefix = sim_ #optional prefix prepended to sequence names, default is using orginal sequence names
+# OPTIONAL PARAMETERS
+prefix = sim_ #optional prefix prepended to sequence names, default is using orginal sequence names
 
 #Optional evolutionary model parameters
 gamma_shape = 5 #dafault is no rate variation across sites
@@ -40,10 +20,46 @@ mutation_clustering = ON
 percent_clustered = 0.25 #The percentage of variable sites whose distance to another site is drawn from the clustering distribution
 exponential_mean = 125 #Minimum allowed value = 2
 
-#ART Optional parameters (for more fine grained control ART can be run seperately on the mutated genomes found in outdir/fasta_files)
+## ART Optional parameters (for more fine grained control ART can be run seperately on the mutated genomes found in outdir/fasta_files)
 #error_model1 = example/ErrprofR1.txt  # If you haven't generated have one of your own using ART, you can use one supplied by ART.
 #error_model2 = example/ErrprofR2.txt  # Un-comment these lines (delete the first #) to set a non-default error profile
-read_length = 250,0 #maximum value with example error profile is 150, use a default or generate adifferent error profile for longer reads.
-fragment_size = 750
+
+## Read length, can be one value or list of comma separated values up to 250bp
+## Read length may be truncated if selected read platform doesn't support it
+read_length = 250
+
+## Insert fragment length.  Can be uniform [fragment_size] 
+## or randomly distributed between [frag_low, frag_high]
+fragment_size = 380
+# frag_low = 600 # Start of random frag length range
+# frag_high = 1000 # End of random frag length range
+# frag_step = 7 # Step size for binning frag length
+
+## Insert fragment length standard deviation.  Can be uniform [stdev_frag_size] 
+## or randomly distributed between [stdev_frag_low, stdev_frag_high]
 stdev_frag_size = 120
-coverage = 10
+# stdev_frag_low = 10 # Start of random frag length stdev range
+# stdev_frag_high = 100 # End of random frag length stdev range
+# stdev_frag_step = 3 # Step size for binning frag length stdev
+
+## Average genomic real coverage.  Can be uniform [coverage] across dataset
+## or randomly distributed between [coverage_low, coverage_high]
+coverage = 20
+# coverage_low = 20 # Start of random coverage range
+# coverage_high = 87 # End of random coverage range
+# coverage_step = 1 # Step size for binning random coverage
+
+## Average QS2 bias to introduce.  Can be 0 (no value provided) across dataset
+# or randomly distributed between [qs2_low, qs2_high]
+# qs2_low = -3 # Start of QS2 bias range
+# qs2_high = 0 # End of QS2 bias range
+# qs2_step = 1 # Step size for binning QS2 bias
+
+# Platform read error profile used to generate reads
+# readProfile = MSv3 # Read platform
+## Supports the following (between read length)
+## Defaults to MiSeq v3 to allow reads up to 250bp
+## GA1 - GenomeAnalyzer I (1-44bp), GA2 - GenomeAnalyzer II (1-75bp)
+## HS10 - HiSeq 1000 (1-100bp), HS20 - HiSeq 2000 1-100bp), HS25 - HiSeq 2500 (1-150bp)
+## HSXn - HiSeqX PCR free (1-150bp), HSXt - HiSeqX TruSeq (1-150bp),  MinS - MiniSeq TruSeq (1-50bp)
+## MSv1 - MiSeq v1 (1-250bp), MSv3 - MiSeq v3 (1-250bp), NS50 - NextSeq500 v2 (1-75bp)

--- a/example.config
+++ b/example.config
@@ -1,19 +1,36 @@
 #REQUIRED PARAMETERS
-treefile_path = example/example.tre #Must be newick or Nexus format, and include branch lengths
-number_of_variable_sites = 20
-base_genome_name = gi #Should be the label of a tip in your tree
-base_genome_path = example/mini_ref.fasta
-output_dir = example_out
-
-
+treefile_path =  /storage/CompGenomics/CompGenomics2019/datasets/listeria/outbreak/listeria.nwk
+number_of_variable_sites = 17
+base_genome_name = CGT3538
+base_genome_path =  /storage/CompGenomics/CompGenomics2019/datasets/listeria/outbreak/ref.fa
+output_dir =  /storage/CompGenomics/Compgenomics2020/datasets/listeria/outbreak
+#coverage_low = 23 # Start of random coverage range
+#coverage_high = 87 # End of random coverage range
+#coverage_step = 1 # Step size for binning random coverage
+#read_length = 150,250 # Read length, can be one value or list of comma separated values
+#frag_low = 600 # Start of random frag length range
+#frag_high = 1000 # End of random frag length range
+#frag_step = 7 # Step size for binning frag length
+#stdev_frag_low = 10 # Start of random frag length stdev range
+#stdev_frag_high = 100 # End of random frag length stdev range
+#stdev_frag_step = 3 # Step size for binning frag length stdev
+#qs2_low = -3 # Start of QS2 bias range
+#qs2_high = 0 # End of QS2 bias range
+#qs2_step = 1 # Step size for binning QS2 bias
+readProfile = MSv3 # Read platform
+# Supports the following (between read length)
+# Defaults to MiSeq v3 to allow reads up to 250bp
+# GA1 - GenomeAnalyzer I (1-44bp), GA2 - GenomeAnalyzer II (1-75bp)
+# HS10 - HiSeq 1000 (1-100bp), HS20 - HiSeq 2000 1-100bp), HS25 - HiSeq 2500 (1-150bp)
+# HSXn - HiSeqX PCR free (1-150bp), HSXt - HiSeqX TruSeq (1-150bp),  MinS - MiniSeq TruSeq (1-50bp)
+# MSv1 - MiSeq v1 (1-250bp), MSv3 - MiSeq v3 (1-250bp), NS50 - NextSeq500 v2 (1-75bp)
 #parameters of evolutionary model (comma seperated), in order ac, ag, at, cg, ct, gc (gc = 1)
 rate_matrix = 1,1,1,1,1,1
 
-#parameters for read simulation
-coverage = 20 #either an integer or a file name of a comma delimited file with tip names and coverage
+
 
 #OPTIONAL PARAMETERS
-prefix = sim_ #optional prefix prepended to sequence names, default is using orginal sequence names
+#prefix = sim_ #optional prefix prepended to sequence names, default is using orginal sequence names
 
 #Optional evolutionary model parameters
 gamma_shape = 5 #dafault is no rate variation across sites
@@ -24,9 +41,9 @@ percent_clustered = 0.25 #The percentage of variable sites whose distance to ano
 exponential_mean = 125 #Minimum allowed value = 2
 
 #ART Optional parameters (for more fine grained control ART can be run seperately on the mutated genomes found in outdir/fasta_files)
-error_model1 = example/ErrprofR1.txt  # If you haven't generated have one of your own using ART, you can use one supplied by ART.
-error_model2 = example/ErrprofR2.txt  # Un-comment these lines (delete the first #) to set a non-default error profile
-read_length = 150 #maximum value with example error profile is 150, use a default or generate adifferent error profile for longer reads.
-fragment_size = 380
+#error_model1 = example/ErrprofR1.txt  # If you haven't generated have one of your own using ART, you can use one supplied by ART.
+#error_model2 = example/ErrprofR2.txt  # Un-comment these lines (delete the first #) to set a non-default error profile
+read_length = 250,0 #maximum value with example error profile is 150, use a default or generate adifferent error profile for longer reads.
+fragment_size = 750
 stdev_frag_size = 120
-
+coverage = 10


### PR DESCRIPTION
I'm not sure if there's any interest in this PR but I use TreeToReads quite a but to simulate data for courses I teach and try and incorporate additional errors and variance to make read sets more realistic.  This PR adds support for all the relevant ART parameters for more control over the simulation (and adding "randomness").  This also adds supports for threads (via the `threads` config item) and `pigz`, if available, for compression.  All the updates are backwards compatible, so existing TTR config files will work the exact same way.

New or updated config options:

`threads`: Number of threads for read simulation, if not set or set to {0,1} only 1 thread is used
`read_length`: Now supports comma separated lists of read length (e.g. 150,250) to generate reads with variable lengths

Fragment length can be randomized using the frag_{low,high,step} options
`frag_low` : Start of random frag length range
`frag_high`: End of random frag length range
`frag_step`:  Step size for binning frag length (e.g. 5 = count from low to high by 5's)

Fragment length standard deviation can be randomized using the stdev_frag_{low,high,step} options
`stdev_frag_low` : Start of random frag length stdev range
`stdev_frag_high`: End of random frag length stdev range
`stdev_frag_step`:  Step size for binning frag length stdev (e.g. 5 = count from low to high by 5's)

Average genomic read coverage.  Can be uniform [coverage] across dataset or randomly distributed between [coverage_low, coverage_high].  
`coverage` = 20
`coverage_low`: Start of random coverage range
`coverage_high`: End of random coverage range
`coverage_step`: Step size for binning random coverage

Average QS2 bias to introduce.  Can be 0 (no value provided) across dataset or randomly distributed between [qs2_low, qs2_high]
`qs2_low`: Start of QS2 bias range
`qs2_high`: End of QS2 bias range
`qs2_step`: Step size for binning QS2 bias

Platform read error profile used to generate reads.  Supports the following (between read length), and defaults to MiSeq v3 to allow reads up to 250bp.  If read lengths are provided that are greater than the profile(s) select support, they'll be truncated to the maxmin of the profile(s) selected
```
GA1 - GenomeAnalyzer I (1-44bp), GA2 - GenomeAnalyzer II (1-75bp)
HS10 - HiSeq 1000 (1-100bp), HS20 - HiSeq 2000 1-100bp), HS25 - HiSeq 2500 (1-150bp)
HSXn - HiSeqX PCR free (1-150bp), HSXt - HiSeqX TruSeq (1-150bp),  MinS - MiniSeq TruSeq (1-50bp)
MSv1 - MiSeq v1 (1-250bp), MSv3 - MiSeq v3 (1-250bp), NS50 - NextSeq500 v2 (1-75bp)
```